### PR TITLE
Update default.conf

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -12,7 +12,7 @@ server {
         internal;
     }
     #Add PHP support
-    location ~ .php {
+    location ~ \.php$ {
         fastcgi_pass   127.0.0.1:9000;
         fastcgi_index  index.php;
         fastcgi_param SCRIPT_FILENAME /var/www/html/$fastcgi_script_name;


### PR DESCRIPTION
fix the location bug when attachment name contains "php" strings.